### PR TITLE
fix: Module state priority

### DIFF
--- a/lbplanner/classes/helpers/modules_helper.php
+++ b/lbplanner/classes/helpers/modules_helper.php
@@ -159,7 +159,7 @@ class modules_helper {
                 return MODULE_STATUS::UPLOADED;
             }
         }
-        
+
         // Check if the module is late.
 
         if ($planid === null) {

--- a/lbplanner/classes/helpers/modules_helper.php
+++ b/lbplanner/classes/helpers/modules_helper.php
@@ -139,8 +139,9 @@ class modules_helper {
     public static function get_module_status(module $module, int $userid, ?int $planid = null): int {
         global $DB;
 
-        if ($planid === null) {
-            $planid = plan_helper::get_plan_id($userid);
+        $grade = $module->get_grade($userid);
+        if ($grade !== null && $grade !== MODULE_GRADE::RIP) {
+            return MODULE_STATUS::DONE;
         }
 
         // Getting some necessary data.
@@ -158,13 +159,12 @@ class modules_helper {
                 return MODULE_STATUS::UPLOADED;
             }
         }
-
-        $grade = $module->get_grade($userid);
-
-        if ($grade !== null && $grade !== MODULE_GRADE::RIP) {
-            return MODULE_STATUS::DONE;
-        }
+        
         // Check if the module is late.
+
+        if ($planid === null) {
+            $planid = plan_helper::get_plan_id($userid);
+        }
 
         $deadline = $module->get_deadline($planid);
 


### PR DESCRIPTION
we now prioritize grades if one exists in determining a module's status. while previous behaviour hasn't caused any obvious bugs so far, it might be the cause of a bug report we received in user feedback